### PR TITLE
ci: Fix NumPy installation with Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ license = "BSD"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-numpy = "^1"
+numpy = [
+    {version = "^1", python = ">=3.7,<3.8"},
+    {version = "^1.24", python = ">=3.8"}
+]
 luna = {git = "https://github.com/greatscottgadgets/luna.git", branch = "main"}
 amaranth = {git = "https://github.com/amaranth-lang/amaranth.git", branch = "main"}
 


### PR DESCRIPTION
Force Poetry to choose a recent NumPy version that has prebuilt wheels for all versions of Python >3.7.
Although I am not particularly happy about how this is fixed, it makes GitHub Actions work.
Another option would be to enforce Python >=3.8.